### PR TITLE
Add image upload

### DIFF
--- a/src/WhoYou.js
+++ b/src/WhoYou.js
@@ -4,6 +4,7 @@ import { ApplicationViews } from "./ApplicationViews";
 import { Login } from "./components/auth/Login";
 import { Register } from "./components/auth/Register";
 import { NavBar } from "./components/nav/NavBar";
+import { UserProvider } from "./components/user/UserProvider";
 
 export const WhoYou = () => {
   return (
@@ -13,8 +14,10 @@ export const WhoYou = () => {
           if (localStorage.getItem("whoyou_user_token")) {
             return (
               <>
-                <NavBar />
-                <ApplicationViews />
+                <UserProvider>
+                  <NavBar />
+                  <ApplicationViews />
+                </UserProvider>
               </>
             );
           } else {

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -1,12 +1,18 @@
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import { Link, useHistory } from "react-router-dom";
 import Navbar from "react-bootstrap/Navbar";
 import Nav from "react-bootstrap/Nav";
 import Logo from "../../images/logo192.png";
 import { Button, FormControl } from "react-bootstrap";
+import { UserContext } from "../user/UserProvider";
 
 export const NavBar = () => {
   const history = useHistory();
+  const { thisUser, getUsers } = useContext(UserContext);
+
+  useEffect(() => {
+    getUsers();
+  }, []);
 
   return (
     <Navbar expand="md">
@@ -14,7 +20,11 @@ export const NavBar = () => {
         as={Link}
         to={`/users/${localStorage.getItem("whoyou_user_id")}`}
       >
-        <img className="navbar__logo" src={Logo} alt="WhoYou" />
+        <img
+          className="navbar__logo"
+          src={thisUser ? thisUser.profile_image_path : Logo}
+          alt="WhoYou"
+        />
       </Navbar.Brand>
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav container ">

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -3,7 +3,7 @@ import { Link, useHistory } from "react-router-dom";
 import Navbar from "react-bootstrap/Navbar";
 import Nav from "react-bootstrap/Nav";
 import Logo from "../../images/logo192.png";
-import { Button, FormControl } from "react-bootstrap";
+import { Button, FormControl, Image } from "react-bootstrap";
 import { UserContext } from "../user/UserProvider";
 
 export const NavBar = () => {
@@ -20,10 +20,11 @@ export const NavBar = () => {
         as={Link}
         to={`/users/${localStorage.getItem("whoyou_user_id")}`}
       >
-        <img
+        <Image
           className="navbar__logo"
           src={thisUser ? thisUser.profile_image_path : Logo}
           alt="WhoYou"
+          rounded
         />
       </Navbar.Brand>
       <Navbar.Toggle aria-controls="basic-navbar-nav" />

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -24,6 +24,7 @@ export const NavBar = () => {
           className="navbar__logo"
           src={thisUser ? thisUser.profile_image_path : Logo}
           alt="WhoYou"
+          width="50%"
           rounded
         />
       </Navbar.Brand>

--- a/src/components/user/UserDetail.js
+++ b/src/components/user/UserDetail.js
@@ -1,10 +1,12 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Button, ListGroup } from "react-bootstrap";
+import { Button, Image, ListGroup } from "react-bootstrap";
 import { useHistory, useParams } from "react-router-dom";
 import { ContentViewRequestContext } from "../content_view_request/ContentViewRequestProvider.js";
 import { BiCheckCircle } from "react-icons/bi";
 import { GoGlobe, GoLock } from "react-icons/go";
 import { ContentContext } from "../content/ContentProvider.js";
+import avitarPlaceholder from "../../images/avitarPlaceholder192.png";
+import { UserContext } from "./UserProvider.js";
 
 export const UserDetail = (props) => {
   const currentUser = parseInt(localStorage.getItem("whoyou_user_id"));
@@ -18,12 +20,24 @@ export const UserDetail = (props) => {
   const { userId } = useParams();
   const history = useHistory();
   const { getContentByUserId } = useContext(ContentContext);
+  const { users, getUsers } = useContext(UserContext);
+  const [userAvitar, setUserAvitar] = useState(avitarPlaceholder);
   var QRCode = require("qrcode.react");
 
   useEffect(() => {
     getContentViewRequests();
     getContentByUserId(userId).then(setUserContent);
+    getUsers();
   }, [userId]);
+
+  useEffect(() => {
+    const user = users.find((u) => u.id === parseInt(userId));
+    user // Check if the user data has been retrieved
+      ? user.profile_image_path === null // Check if the user's profile image is null
+        ? setUserAvitar(avitarPlaceholder)
+        : setUserAvitar(user.profile_image_path)
+      : setUserAvitar(avitarPlaceholder);
+  }, [users]);
 
   return (
     <>
@@ -37,7 +51,7 @@ export const UserDetail = (props) => {
             />
           </>
         ) : (
-          ""
+          <Image className="d-flex mx-auto" src={userAvitar} width="30%" />
         )}
 
         {userContent.map((content) => {

--- a/src/components/user/UserDetail.js
+++ b/src/components/user/UserDetail.js
@@ -51,7 +51,12 @@ export const UserDetail = (props) => {
             />
           </>
         ) : (
-          <Image className="d-flex mx-auto" src={userAvitar} width="30%" />
+          <Image
+            className="d-flex mx-auto"
+            src={userAvitar}
+            width="30%"
+            rounded
+          />
         )}
 
         {userContent.map((content) => {

--- a/src/components/user/UserEdit.js
+++ b/src/components/user/UserEdit.js
@@ -1,19 +1,21 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Button, Col, Form } from "react-bootstrap";
+import { Button, Col, Form, Image } from "react-bootstrap";
 import { useHistory, useParams } from "react-router-dom";
 import { ContentViewRequestContext } from "../content_view_request/ContentViewRequestProvider.js";
 import { ContentContext } from "../content/ContentProvider.js";
 import ToggleButton from "react-toggle-button";
 import { UserContext } from "./UserProvider.js";
+import avitarPlaceholder from "../../images/avitarPlaceholder192.png";
 
 export const UserEdit = (props) => {
   const currentUser = parseInt(localStorage.getItem("whoyou_user_id"));
   const [userContent, setUserContent] = useState([]);
+  const { users, getUsers } = useContext(UserContext);
   const { getContentByUserId, updateContent } = useContext(ContentContext);
   const { getContentViewRequests } = useContext(ContentViewRequestContext);
   const { updateUserAvitar } = useContext(UserContext);
   const { userId } = useParams();
-  const [userAvitar, setUserAvitar] = useState(""); //TODO: the user avitar state should be initially set to the user's current profile
+  const [userAvitar, setUserAvitar] = useState(avitarPlaceholder); //TODO: the user avitar state should be initially set to the user's current profile
   const history = useHistory();
 
   useEffect(() => {
@@ -23,7 +25,12 @@ export const UserEdit = (props) => {
     }
     getContentViewRequests();
     getContentByUserId(userId).then(setUserContent);
+    getUsers();
   }, []);
+
+  useEffect(() => {
+    setUserAvitar(users.find((u) => u.id === currentUser).profile_image_path);
+  }, [users]);
 
   const handleValueChange = (changeEvent, index) => {
     let updatedUserContent = userContent.slice();
@@ -53,6 +60,7 @@ export const UserEdit = (props) => {
     <>
       <Form className="container">
         <Form.Group>
+          <Image src={userAvitar} width="10%" />
           <Form.Label>Profile Image </Form.Label>
           <Form.Row>
             <input type="file" onChange={createUserAvitarString} />

--- a/src/components/user/UserEdit.js
+++ b/src/components/user/UserEdit.js
@@ -15,7 +15,7 @@ export const UserEdit = (props) => {
   const { getContentViewRequests } = useContext(ContentViewRequestContext);
   const { updateUserAvitar } = useContext(UserContext);
   const { userId } = useParams();
-  const [userAvitar, setUserAvitar] = useState(avitarPlaceholder); //TODO: the user avitar state should be initially set to the user's current profile
+  const [userAvitar, setUserAvitar] = useState(avitarPlaceholder);
   const history = useHistory();
 
   useEffect(() => {

--- a/src/components/user/UserEdit.js
+++ b/src/components/user/UserEdit.js
@@ -45,24 +45,26 @@ export const UserEdit = (props) => {
 
   const createUserAvitarString = (event) => {
     getBase64(event.target.files[0], (base64ImageString) => {
-      console.log("Base64 of file is", base64ImageString);
       setUserAvitar(base64ImageString);
-
-      // Update a component state variable to the value of base64ImageString
     });
   };
 
   return (
     <>
       <Form className="container">
-        <input type="file" onChange={createUserAvitarString} />
-        <button
-          onClick={() => {
-            updateUserAvitar(currentUser, userAvitar);
-          }}
-        >
-          Upload
-        </button>
+        <Form.Group>
+          <Form.Label>Profile Image </Form.Label>
+          <Form.Row>
+            <input type="file" onChange={createUserAvitarString} />
+            <Button
+              onClick={() => {
+                updateUserAvitar(currentUser, userAvitar);
+              }}
+            >
+              Upload
+            </Button>
+          </Form.Row>
+        </Form.Group>
         {userContent.map((content, index) => {
           return (
             <Form.Group key={content.id} className="col">

--- a/src/components/user/UserEdit.js
+++ b/src/components/user/UserEdit.js
@@ -4,13 +4,16 @@ import { useHistory, useParams } from "react-router-dom";
 import { ContentViewRequestContext } from "../content_view_request/ContentViewRequestProvider.js";
 import { ContentContext } from "../content/ContentProvider.js";
 import ToggleButton from "react-toggle-button";
+import { UserContext } from "./UserProvider.js";
 
 export const UserEdit = (props) => {
   const currentUser = parseInt(localStorage.getItem("whoyou_user_id"));
   const [userContent, setUserContent] = useState([]);
   const { getContentByUserId, updateContent } = useContext(ContentContext);
   const { getContentViewRequests } = useContext(ContentViewRequestContext);
+  const { updateUserAvitar } = useContext(UserContext);
   const { userId } = useParams();
+  const [userAvitar, setUserAvitar] = useState(""); //TODO: the user avitar state should be initially set to the user's current profile
   const history = useHistory();
 
   useEffect(() => {
@@ -34,9 +37,32 @@ export const UserEdit = (props) => {
     setUserContent(updatedUserContent);
   };
 
+  const getBase64 = (file, callback) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => callback(reader.result));
+    reader.readAsDataURL(file);
+  };
+
+  const createUserAvitarString = (event) => {
+    getBase64(event.target.files[0], (base64ImageString) => {
+      console.log("Base64 of file is", base64ImageString);
+      setUserAvitar(base64ImageString);
+
+      // Update a component state variable to the value of base64ImageString
+    });
+  };
+
   return (
     <>
       <Form className="container">
+        <input type="file" onChange={createUserAvitarString} />
+        <button
+          onClick={() => {
+            updateUserAvitar(currentUser, userAvitar);
+          }}
+        >
+          Upload
+        </button>
         {userContent.map((content, index) => {
           return (
             <Form.Group key={content.id} className="col">

--- a/src/components/user/UserEdit.js
+++ b/src/components/user/UserEdit.js
@@ -29,7 +29,10 @@ export const UserEdit = (props) => {
   }, []);
 
   useEffect(() => {
-    setUserAvitar(users.find((u) => u.id === currentUser).profile_image_path);
+    const thisUser = users.find((u) => u.id === currentUser);
+    if (thisUser) {
+      setUserAvitar(thisUser.profile_image_path);
+    }
   }, [users]);
 
   const handleValueChange = (changeEvent, index) => {

--- a/src/components/user/UserList.js
+++ b/src/components/user/UserList.js
@@ -36,8 +36,9 @@ export const UserList = () => {
             <Image
               src={user.profile_image_path || avitarPlaceholder}
               width="10%"
+              rounded
             />
-            {user.name}
+            <div className="d-inline-flex mx-2">{user.name}</div>
           </ListGroup.Item>
         );
       })}

--- a/src/components/user/UserList.js
+++ b/src/components/user/UserList.js
@@ -33,7 +33,10 @@ export const UserList = () => {
             key={user.id}
             onClick={() => history.push(`users/${user.id}`)}
           >
-            <Image src={avitarPlaceholder} width="10%" />
+            <Image
+              src={user.profile_image_path || avitarPlaceholder}
+              width="10%"
+            />
             {user.name}
           </ListGroup.Item>
         );

--- a/src/components/user/UserProvider.js
+++ b/src/components/user/UserProvider.js
@@ -8,16 +8,18 @@ export const UserProvider = (props) => {
   const [thisUser, setThisUser] = useState({});
   let currentUser = parseInt(localStorage.getItem("whoyou_user_id"));
 
-  const setThisUserToCurrent = () => {
-    const thisUserFound = users.find((user) => user.id === currentUser);
+  const setThisUserToCurrent = (newUsers) => {
+    const thisUserFound = newUsers.find((user) => user.id === currentUser);
     setThisUser(thisUserFound);
   };
 
   const getUsers = () => {
     return fetch(`${ServerPath}/users`)
       .then((res) => res.json())
-      .then(setUsers)
-      .then(() => setThisUserToCurrent());
+      .then((newUsers) => {
+        setThisUserToCurrent(newUsers);
+        setUsers(newUsers);
+      });
   };
 
   const updateUserAvitar = (userId, avitar) => {

--- a/src/components/user/UserProvider.js
+++ b/src/components/user/UserProvider.js
@@ -14,7 +14,7 @@ export const UserProvider = (props) => {
 
   const updateUserAvitar = (userId, avitar) => {
     return fetch(`${ServerPath}/users/${userId}`, {
-      method: "PUT",
+      method: "PATCH",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Token ${localStorage.getItem("whoyou_user_token")}`,

--- a/src/components/user/UserProvider.js
+++ b/src/components/user/UserProvider.js
@@ -5,11 +5,19 @@ export const UserContext = React.createContext();
 
 export const UserProvider = (props) => {
   const [users, setUsers] = useState([]);
+  const [thisUser, setThisUser] = useState({});
+  let currentUser = parseInt(localStorage.getItem("whoyou_user_id"));
+
+  const setThisUserToCurrent = () => {
+    const thisUserFound = users.find((user) => user.id === currentUser);
+    setThisUser(thisUserFound);
+  };
 
   const getUsers = () => {
     return fetch(`${ServerPath}/users`)
       .then((res) => res.json())
-      .then(setUsers);
+      .then(setUsers)
+      .then(() => setThisUserToCurrent());
   };
 
   const updateUserAvitar = (userId, avitar) => {
@@ -39,6 +47,7 @@ export const UserProvider = (props) => {
     <UserContext.Provider
       value={{
         users,
+        thisUser,
         getUsers,
         searchUsers,
         updateUserAvitar,

--- a/src/components/user/UserProvider.js
+++ b/src/components/user/UserProvider.js
@@ -12,6 +12,19 @@ export const UserProvider = (props) => {
       .then(setUsers);
   };
 
+  const updateUserAvitar = (userId, avitar) => {
+    return fetch(`${ServerPath}/users/${userId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${localStorage.getItem("whoyou_user_token")}`,
+      },
+      body: JSON.stringify({
+        profile_image_path: avitar,
+      }),
+    });
+  };
+
   const searchUsers = (searchString) => {
     if (searchString != "") {
       return fetch(`${ServerPath}/users?name=${searchString}`)
@@ -28,6 +41,7 @@ export const UserProvider = (props) => {
         users,
         getUsers,
         searchUsers,
+        updateUserAvitar,
       }}
     >
       {props.children}

--- a/src/components/user/UserProvider.js
+++ b/src/components/user/UserProvider.js
@@ -22,7 +22,7 @@ export const UserProvider = (props) => {
       body: JSON.stringify({
         profile_image_path: avitar,
       }),
-    });
+    }).then(getUsers);
   };
 
   const searchUsers = (searchString) => {


### PR DESCRIPTION
# Description
Users would like to upload images to the site. To make this happen, this pr add the ability to upload an image file when editing a user's profile. The image is then converted to a base 64 string, and passed across to the server. When a user's profile is viewed, the app looks for a file path to the image, but if it's not available, it uses the default site image.
## Type of change
- [ ] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Profile images can be viewed in the nav
- [ ] Profile images can be viewed on a user's page
- [ ] Profile image can be uploaded from a user's edit page
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings