### PR TITLE
prevent missing image in nav bar when avitar path is null

### DIFF
--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -14,6 +14,15 @@ export const NavBar = () => {
     getUsers();
   }, []);
 
+  const getAvitarImage = () => {
+    if (thisUser) {
+      if (thisUser.profile_image_path !== null) {
+        return thisUser.profile_image_path;
+      }
+    }
+    return Logo;
+  };
+
   return (
     <Navbar expand="md">
       <Navbar.Brand
@@ -22,7 +31,7 @@ export const NavBar = () => {
       >
         <Image
           className="navbar__logo"
-          src={thisUser ? thisUser.profile_image_path : Logo}
+          src={getAvitarImage()}
           alt="WhoYou"
           width="50%"
           rounded


### PR DESCRIPTION
# Description
When viewing the site as a user with no profile image assigned, the nav image was shown as missing, instead of the default. This change adds logic to check if the image path is null.
## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] tested by serving locally as a user with no profile image
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings